### PR TITLE
Separate error handling and input parsing

### DIFF
--- a/add_rating.py
+++ b/add_rating.py
@@ -7,41 +7,54 @@ from issue_ingestion import (
     load_issue,
     post_summary,
     save_books,
-    validate_book,
     validate_reviewer,
     warn,
 )
 
+class ParsingError(ValueError):
+    """Raised when a rating cannot be parsed."""
 
-def validate_rating(rating: str, club: dict, warnings: list[str]):
+
+def parse_german_grade(rating: str) -> int:
+    if not (rating.isdigit() and 1 <= int(rating) <= 15):
+        raise ParsingError(
+            f"Rating '{rating}' is not an integer between 1 and 15."
+        )
+    return int(rating)
+
+
+def parse_five_star(rating: str) -> float:
+    try:
+        value = float(rating)
+    except ValueError as exc:
+        raise ParsingError(f"Rating '{rating}' is not a valid number.") from exc
+
+    if not (0.5 <= value <= 5.0 and (value * 2) % 1 == 0):
+        raise ParsingError(
+            f"Rating '{rating}' must be a multiple of 0.5 between 0.5 and 5."
+        )
+
+    return value
+
+
+RATING_PARSERS = {
+    "german_grades": parse_german_grade,
+    "five_stars": parse_five_star,
+}
+
+
+def parse_rating(rating: str, club: dict) -> int | float:
     system_type = club.get("rating_system_id", "german_grades")
 
-    if system_type == "german_grades":
-        if not (rating.isdigit() and 1 <= int(rating) <= 15):
-            warnings.append(
-                warn(f"Rating '{rating}' is not an integer between 1 and 15.")
-            )
-            return None
-        return int(rating)
+    try:
+        parser = RATING_PARSERS[system_type]
+    except KeyError as exc:
+        raise ParsingError(f"Unknown rating system '{system_type}'.") from exc
 
-    if system_type == "five_stars":
-        try:
-            value = float(rating)
-        except ValueError:
-            warnings.append(warn(f"Rating '{rating}' is not a valid number."))
-            return None
-        if not (0.5 <= value <= 5.0 and (value * 2) % 1 == 0):
-            warnings.append(
-                warn(f"Rating '{rating}' must be a multiple of 0.5 between 0.5 and 5.")
-            )
-            return None
-        return value
-
-    warnings.append(warn(f"Unknown rating system type '{system_type}'."))
-    return None
+    return parser(rating)
 
 
-def build_summary(
+def build_rating_summary(
     *,
     book_id: str,
     reviewer: str,
@@ -80,6 +93,7 @@ def parse_issue():
     """
     warnings = []
     notices = []
+    success = True
 
     event = load_issue()
     body = event.get("issue", {}).get("body", "")
@@ -91,28 +105,30 @@ def parse_issue():
 
     books = load_books(BOOKS_FILE)
     club = load_club(CLUB_FILE)
-    book, failed = validate_book(
-        books=books,
-        book_id=book_id,
-        warnings=warnings,
-    )
+
+    book = books.get(book_id)
+    if not book:
+        warnings.append(warn(f"Book id '{book_id}' not found! Aborted."))
+        success = False
 
     if book:
-        failed = (
-            validate_reviewer(
+        if not validate_reviewer(
                 book=book,
                 reviewer=reviewer,
                 participant_field="ratings",
-                warnings=warnings,
-            )
-            or failed
-        )
+            ):
+                warnings.append(warn(f"Reviewer '{reviewer}' was no participant. Aborted."))
+                success = False
 
-    parsed_rating = validate_rating(rating, club, warnings)
+    try:
+        parsed_rating = parse_rating(rating, club, warnings)
+    except ParsingError as e:
+        warnings.append(warn(str(e)))
+        success = False
+        parsed_rating = None # This should not be necessary, but ensures a set variable.
 
-    success = not failed and parsed_rating is not None
 
-    summary = build_summary(
+    summary = build_rating_summary(
         book_id=book_id,
         reviewer=reviewer,
         rating=rating,

--- a/add_review.py
+++ b/add_review.py
@@ -5,18 +5,17 @@ from issue_ingestion import (
     load_issue,
     post_summary,
     save_books,
-    validate_book,
     validate_reviewer,
+    warn,
 )
 
 
-def build_summary(
+def build_review_summary(
     *,
     book_id: str,
     reviewer: str,
     review: str,
     warnings: list[str],
-    notices: list[str],
     success: bool,
 ) -> str:
     lines = ["# SUMMARY"]
@@ -32,16 +31,9 @@ def build_summary(
         for warning in warnings:
             lines.append(f"> - {warning}")
 
-    if notices:
-        lines.append("### Notes")
-        lines.append("\n> [!NOTE]\n>")
-
-        for notice in notices:
-            lines.append(f"> - {notice}")
-
     return "\n".join(lines)
 
-def get_book_id_from_title(books, title: str) -> tuple[str, bool]:
+def get_book_id_from_title(books, title: str) -> str:
     from rapidfuzz import process, fuzz
     # Map titles to book IDs
     title_to_id = {
@@ -50,7 +42,7 @@ def get_book_id_from_title(books, title: str) -> tuple[str, bool]:
     }
 
     if not title_to_id:
-        return None, False
+        return None
 
     match = process.extractOne(
         title,
@@ -59,14 +51,14 @@ def get_book_id_from_title(books, title: str) -> tuple[str, bool]:
     )
 
     if match is None:
-        return None, False
+        return None
 
     matched_title, score, _ = match
 
     if score < 85: # 85 is a somewhat arbitrary threshold
-        return None, False
+        return None
 
-    return title_to_id[matched_title], True
+    return title_to_id[matched_title]
 
 def parse_issue():
     """
@@ -74,7 +66,7 @@ def parse_issue():
     Extracts book_id, reviewer, and review text from issue.
     """
     warnings = []
-    notices = []
+    success = True
 
     event = load_issue()
     body = event.get("issue", {}).get("body", "")
@@ -83,58 +75,44 @@ def parse_issue():
 
     fields = extract_issue_fields(body, "book title", "reviewer", "review")
     title = fields["book title"]
-    book_id, found_book = get_book_id_from_title(books, title)
     reviewer = fields["reviewer"]
     review = fields["review"]
 
-    if not found_book:
-        warnings.append(f"Book not found for title: {title}")
-        summary = build_summary(
-            book_id="UNKNOWN",
-            reviewer=reviewer,
-            review=review,
-            warnings=warnings,
-            notices=notices,
-            success=False,
-        )
-        post_summary(summary)
-        return False
 
-    book, failed = validate_book(
-        books=books,
-        book_id=book_id,
-        warnings=warnings,
-    )
+    book_id = get_book_id_from_title(books, title)
+    if not book_id:
+        warnings.append(warn(f"Book not found for title: {title}. Aborted."))
+        success = False
+    
 
+    book = books.get(book_id)
+    if not book:
+        warnings.append(warn(f"Book id '{book_id}' not found! Aborted."))
+        success = False
+    
     if book:
-        failed = (
-            validate_reviewer(
+        if not validate_reviewer(
                 book=book,
                 reviewer=reviewer,
                 participant_field="reviews",
-                warnings=warnings,
-            )
-            or failed
-        )
+            ):
+                warnings.append(warn(f"Reviewer '{reviewer}' was no participant. Aborted."))
+                success = False
 
-    success = not failed
 
-    summary = build_summary(
+    summary = build_review_summary(
         book_id=book_id,
         reviewer=reviewer,
         review=review,
         warnings=warnings,
-        notices=notices,
-        success=success,
+        success=True,
     )
-
     post_summary(summary)
 
     if not success:
         return False
-
+    
     book["reviews"][reviewer] = review
-
     save_books(BOOKS_FILE, books)
 
     return True

--- a/issue_ingestion.py
+++ b/issue_ingestion.py
@@ -123,32 +123,11 @@ def post_summary(summary: str) -> None:
 
 
 # ---------- Validation ----------
-def validate_book(
-    *,
-    books: dict,
-    book_id: str,
-    warnings: list[str],
-) -> tuple[dict | None, bool]:
-    book = books.get(book_id)
-    if not book:
-        warnings.append(warn(f"Book id '{book_id}' not found! Exiting."))
-        return None, True
-    return book, False
-
-
 def validate_reviewer(
     *,
     book: dict,
     reviewer: str,
     participant_field: str,
-    warnings: list[str],
 ) -> bool:
     participants = list(book[participant_field].keys())
-    if reviewer not in participants:
-        warnings.append(
-            warn(
-                f"Reviewer '{reviewer}' was no participant ({join_and(participants)})."
-            )
-        )
-        return True
-    return False
+    return reviewer in participants


### PR DESCRIPTION
This change separates error handling and input parsing/validation. For book_id, book and reviewer, this is done by first parsing/validating the input, and then handling the error if the input is bad. In the case of ratings, where the error depends on the club and its rating system, this is handled by a dict for different parsers. Each parser can then raise its own error. As an additional benefit, adding more rating systems becomes cleaner.

Also, the different build summary functions now have different names.